### PR TITLE
Fix name of zshenv dotfile

### DIFF
--- a/zsh/zshenv.symlink
+++ b/zsh/zshenv.symlink
@@ -1,3 +1,6 @@
+export EDITOR=vim
+export VISUAL="$EDITOR"
+
 # set PATH so it includes user's private bin if it exists
 if [ -d "$HOME/bin" ] ; then
     PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
Fix name of zshenv dotfile, which wasn't sourced when running macos (zsh v5.8).
